### PR TITLE
Updates q42022

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,15 +19,16 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 11
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,39 @@
+# Development guide
+
+## Development environment setup
+
+Requirements:
+
+* Java >= 11 (openjdk 11.0.16 2022-07-19)
+* Maven
+
+To start a development Jenkins instance with this plugin loaded, run:
+
+~~~bash
+./devscripts/run.sh
+~~~
+
+You can then access Jenkins on http://127.0.0.1:8080/jenkins/
+
+## Troubleshooting: Jenkins can't find a particular function
+
+### Cause
+
+The build process (`mvn compile`) generates `target/classes/META-INF/annotations/hudson.Extension.txt`, which tells Jenkins which classes from the plugin file to load. Sometimes Visual Studio Code's Java support's auto-build feature (which doesn't use Maven under the hood) nukes this file, which makes Jenkins improperly load our plugin.
+
+This can normally be solved by fully rebuilding the project (`mvn clean && mvn compile`). But Visual Studio Code sometimes enters an infinite auto-build loop, it which it tries to build the project over and over again. The Java support's auto-build feature builds all the Java files continuously (while not generating `hudson.Extension.txt`), so that `mvn compile` believes that there's nothing to do. As a result, `hudson.Extension.txt` is never generated.
+
+You can check whether there's an auto-build loop by invoking the "Java: Show Build Job Status" command.
+
+### Solution
+
+1. Run the "Java: Clean Java Language Server Workspace" command to stop the auto-build loop.
+2. Run `mvn clean && mvn compile`
+
+## Release
+
+~~~bash
+mvn release:prepare
+mvn release:perform
+git push
+~~~

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    [platform: 'linux', jdk: '11'],
+    [platform: 'windows', jdk: '11'],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>venafi-codesigning</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>1.1.0</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.361.2</jenkins.version>
@@ -114,7 +114,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>venafi-codesigning-1.1.0</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>venafi-codesigning</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.361.2</jenkins.version>
@@ -114,7 +114,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>venafi-codesigning-1.1.0</tag>
+      <tag>HEAD</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.0</version>
+        <version>4.47</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -12,8 +12,8 @@
     <version>1.0.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.164.3</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.361.2</jenkins.version>
+        <java.level>11</java.level>
         <workflow.version>2.0</workflow.version>
     </properties>
 
@@ -48,10 +48,10 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- Pick up common dependencies for 2.164.x: https://github.com/jenkinsci/bom#usage -->
+                <!-- Pick up common dependencies for 2.361.x: https://github.com/jenkinsci/bom#usage -->
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.164.x</artifactId>
-                <version>3</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1607.va_c1576527071</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -66,17 +66,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.0</version>
         </dependency>
 
         <!-- Dependencies for allowing inspection with IntelliSense.

--- a/pom.xml
+++ b/pom.xml
@@ -32,16 +32,16 @@
       <developer>
         <id>avwsolutions</id>
         <name>Arnold van Wijnbergen</name>
-        <email>a.vanwijnbergen@fullstaq.com</email>
-        <organization>Fullstaq</organization>
-        <organizationUrl>https://fullstaq.com</organizationUrl>
+        <email>arnold@qensus.com</email>
+        <organization>Qensus Labs</organization>
+        <organizationUrl>https://qensus.com</organizationUrl>
       </developer>
       <developer>
-        <id>FooBarWidget</id>
-        <name>Hongli Lai</name>
-        <email>h.lai@fullstaq.com</email>
-        <organization>Fullstaq</organization>
-        <organizationUrl>https://fullstaq.com</organizationUrl>
+        <id>sanhi</id>
+        <name>Sander Hindimith</name>
+        <email>sander@hindimith.nl</email>
+        <organization>Qensus Labs</organization>
+        <organizationUrl>https://qensus.com</organizationUrl>
       </developer>
     </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,14 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>venafi-codesigning</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.361.2</jenkins.version>
         <java.level>11</java.level>
         <workflow.version>2.0</workflow.version>
+        <revision>1.1.0</revision>
+        <changelist>-SNAPSHOT</changelist>
     </properties>
 
     <name>Venafi CodeSign Protect</name>


### PR DESCRIPTION
### Release v1.1.0

**This is a new minor release with backward compatible changes!** 

**Important to ensure you are running at least version 2.361.2 or greater!**

Possible breaking changes:

- Updates to Jenkins core 2.361.2 and introducing JDK11.

Non-breaking changes:

- Upgrades credentials plugin (included in bom) to solve outstanding issue.
- Upgrade base plugins towards bom-2.361.x, version 1607.va_c1576527071
- Bumps various dependencies versions in order to fix their security issues.
- Minor documentation updates.
- Minor Actions updates to make the workflow JDK11 compatible.