### PR TITLE
Add public getCredential to solve Syntax generator bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>venafi-codesigning</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.361.2</jenkins.version>
@@ -118,7 +118,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>venafi-codesigning-1.2.1</tag>
+      <tag>HEAD</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>venafi-codesigning</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.1</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.361.2</jenkins.version>
@@ -118,7 +118,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>venafi-codesigning-1.2.1</tag>
   </scm>
     <repositories>
         <repository>

--- a/src/main/java/io/jenkins/plugins/venaficodesigning/JarSignerVerifyBuilder.java
+++ b/src/main/java/io/jenkins/plugins/venaficodesigning/JarSignerVerifyBuilder.java
@@ -102,6 +102,10 @@ public class JarSignerVerifyBuilder extends Builder implements SimpleBuildStep {
         return certLabel;
     }
 
+    public Credential getCredential() {
+        return credential;
+    }
+
     public String getVenafiClientToolsDir() {
         return venafiClientToolsDir;
     }

--- a/src/main/java/io/jenkins/plugins/venaficodesigning/SignToolBuilder.java
+++ b/src/main/java/io/jenkins/plugins/venaficodesigning/SignToolBuilder.java
@@ -99,6 +99,10 @@ public class SignToolBuilder extends Builder implements SimpleBuildStep {
         return subjectName;
     }
 
+    public Credential getCredential() {
+        return credential;
+    }
+
     @DataBoundSetter
     public void setSubjectName(String value) {
         if (value.equals("")) {

--- a/src/main/java/io/jenkins/plugins/venaficodesigning/SignToolVerifyBuilder.java
+++ b/src/main/java/io/jenkins/plugins/venaficodesigning/SignToolVerifyBuilder.java
@@ -78,6 +78,10 @@ public class SignToolVerifyBuilder extends Builder implements SimpleBuildStep {
         return signToolPath;
     }
 
+    public Credential getCredential() {
+        return credential;
+    }
+
     @DataBoundSetter
     public void setSignToolPath(String value) {
         if (value.equals("")) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

`UI error step <object of type io.jenkins.plugins.venaficodesigning.SignToolVerifyBuilder>`

The following is found in the logs. Public getCredential getter method are missing for both of those three. Fix created to add this.

```
2023-02-19 10:48:46.616+0000 [id=18]    WARNING o.j.p.s.d.DescribableParameter#uncoerce: failed to uncoerce io.jenkins.plugins.venaficodesigning.SignToolVerifyBuilder@5b39f3d5
java.lang.UnsupportedOperationException: no public field ‘credential’ (or getter method) found in class io.jenkins.plugins.venaficodesigning.SignToolVerifyBuilder
.....
```

* **What is the new behavior (if this is a feature change)?**

Fixes the errors when generating pipeline code and shows boilerplate code instead of the UI error.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)

No

* **Other information**: